### PR TITLE
Fix typo in start.js comment

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -66,7 +66,7 @@ const env = {
 
 if (process.env.DEBUG) {
   // If this is not set, the debugger will pause on the outer process rather
-  // than the relauncehd process making it harder to debug.
+  // than the relaunched process making it harder to debug.
   env.QWEN_CLI_NO_RELAUNCH = 'true';
 }
 const child = spawn('node', nodeArgs, { stdio: 'inherit', env });


### PR DESCRIPTION
## Summary
- fix typo `relauncehd` -> `relaunched` in `scripts/start.js`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ba762a3c832893900c4e464c16d6