### PR TITLE
Fix path shortening logic

### DIFF
--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shortenPath } from './paths.js';
+
+// Utility to quickly compute length
+
+describe('shortenPath', () => {
+  it('returns original path when shorter than limit', () => {
+    const p = '/tmp/a.txt';
+    expect(shortenPath(p, 20)).toBe(p);
+  });
+
+  it('shortens long paths and ensures result does not exceed max length', () => {
+    const p = '/Users/testuser/projects/someproject/src/components/Button/index.tsx';
+    const maxLen = 35;
+    const shortened = shortenPath(p, maxLen);
+    expect(shortened.length).toBeLessThanOrEqual(maxLen);
+    // Should keep file name at end
+    expect(shortened.endsWith('index.tsx')).toBe(true);
+  });
+
+  it('handles single segment paths', () => {
+    const p = '/singleextremelylongfilename.txt';
+    const maxLen = 20;
+    const shortened = shortenPath(p, maxLen);
+    expect(shortened.length).toBeLessThanOrEqual(maxLen);
+    expect(shortened.endsWith('name.txt')).toBe(true);
+  });
+});

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -88,7 +88,7 @@ export function shortenPath(filePath: string, maxLen: number = 35): string {
   // As a final check, if the result is somehow still too long
   // truncate the result string from the beginning, prefixing with "...".
   if (result.length > maxLen) {
-    return '...' + result.substring(result.length - maxLen - 3);
+    return '...' + result.substring(result.length - (maxLen - 3));
   }
 
   return result;


### PR DESCRIPTION
## Summary
- ensure shortened paths keep exactly `maxLen` characters in paths.ts
- add vitest coverage for `shortenPath`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b691d18c8328b50f322b6826c81d