### PR TITLE
Add tool cancellation support

### DIFF
--- a/packages/cli/src/ui/hooks/useQwenStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useQwenStream.test.tsx
@@ -500,6 +500,7 @@ describe('useQwenStream', () => {
     mockUseReactToolScheduler.mockReturnValue([
       [],
       mockScheduleToolCalls,
+      mockCancelAllToolCalls,
       mockMarkToolsAsSubmitted,
     ]);
     const { rerender } = renderHook(() =>
@@ -522,6 +523,7 @@ describe('useQwenStream', () => {
     mockUseReactToolScheduler.mockReturnValue([
       completedToolCalls,
       mockScheduleToolCalls,
+      mockCancelAllToolCalls,
       mockMarkToolsAsSubmitted,
     ]);
 
@@ -565,6 +567,7 @@ describe('useQwenStream', () => {
     mockUseReactToolScheduler.mockReturnValue([
       [],
       mockScheduleToolCalls,
+      mockCancelAllToolCalls,
       mockMarkToolsAsSubmitted,
     ]);
     const { rerender } = renderHook(() =>
@@ -587,6 +590,7 @@ describe('useQwenStream', () => {
     mockUseReactToolScheduler.mockReturnValue([
       cancelledToolCalls,
       mockScheduleToolCalls,
+      mockCancelAllToolCalls,
       mockMarkToolsAsSubmitted,
     ]);
 
@@ -868,7 +872,7 @@ describe('useQwenStream', () => {
       expect(result.current.streamingState).toBe(StreamingState.Idle);
     });
 
-    it('should not cancel if a tool call is in progress (not just responding)', async () => {
+    it('should cancel executing tools when escape is pressed', async () => {
       const toolCalls: TrackedToolCall[] = [
         {
           request: { callId: 'call1', name: 'tool1', args: {} },
@@ -893,8 +897,9 @@ describe('useQwenStream', () => {
       // Try to cancel
       simulateEscapeKeyPress();
 
-      // Nothing should happen because the state is not `Responding`
-      expect(abortSpy).not.toHaveBeenCalled();
+      expect(abortSpy).toHaveBeenCalled();
+      expect(mockCancelAllToolCalls).toHaveBeenCalled();
+      expect(result.current.streamingState).toBe(StreamingState.Idle);
     });
   });
 
@@ -933,6 +938,7 @@ describe('useQwenStream', () => {
       mockUseReactToolScheduler.mockReturnValue([
         [],
         mockScheduleToolCalls,
+        mockCancelAllToolCalls,
         mockMarkToolsAsSubmitted,
       ]);
 
@@ -962,6 +968,7 @@ describe('useQwenStream', () => {
       mockUseReactToolScheduler.mockReturnValue([
         [completedToolCall],
         mockScheduleToolCalls,
+        mockCancelAllToolCalls,
         mockMarkToolsAsSubmitted,
       ]);
 
@@ -1010,6 +1017,7 @@ describe('useQwenStream', () => {
       mockUseReactToolScheduler.mockReturnValue([
         [completedToolCall],
         mockScheduleToolCalls,
+        mockCancelAllToolCalls,
         mockMarkToolsAsSubmitted,
       ]);
 

--- a/packages/cli/src/ui/hooks/useQwenStream.ts
+++ b/packages/cli/src/ui/hooks/useQwenStream.ts
@@ -109,7 +109,7 @@ export const useQwenStream = (
     return new GitService(config.getProjectRoot());
   }, [config]);
 
-  const [toolCalls, scheduleToolCalls, markToolsAsSubmitted] =
+  const [toolCalls, scheduleToolCalls, cancelAllToolCalls, markToolsAsSubmitted] =
     useReactToolScheduler(
       (completedToolCallsFromScheduler) => {
         // This onComplete is called when ALL scheduled tools for a given batch are done.
@@ -179,6 +179,15 @@ export const useQwenStream = (
       }
       turnCancelledRef.current = true;
       abortControllerRef.current?.abort();
+      if (
+        toolCalls.some((tc) =>
+          ['executing', 'scheduled', 'validating', 'awaiting_approval'].includes(
+            tc.status,
+          ),
+        )
+      ) {
+        cancelAllToolCalls();
+      }
       if (pendingHistoryItemRef.current) {
         addItem(pendingHistoryItemRef.current, Date.now());
       }

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -63,6 +63,8 @@ export type TrackedToolCall =
   | TrackedCompletedToolCall
   | TrackedCancelledToolCall;
 
+export type CancelAllToolCallsFn = () => void;
+
 export function useReactToolScheduler(
   onComplete: (tools: CompletedToolCall[]) => void,
   config: Config,
@@ -70,7 +72,12 @@ export function useReactToolScheduler(
     React.SetStateAction<HistoryItemWithoutId | null>
   >,
   getPreferredEditor: () => EditorType | undefined,
-): [TrackedToolCall[], ScheduleFn, MarkToolsAsSubmittedFn] {
+): [
+  TrackedToolCall[],
+  ScheduleFn,
+  CancelAllToolCallsFn,
+  MarkToolsAsSubmittedFn,
+] {
   const [toolCallsForDisplay, setToolCallsForDisplay] = useState<
     TrackedToolCall[]
   >([]);
@@ -174,7 +181,12 @@ export function useReactToolScheduler(
     [],
   );
 
-  return [toolCallsForDisplay, schedule, markToolsAsSubmitted];
+  return [
+    toolCallsForDisplay,
+    schedule,
+    scheduler.cancelAllToolCalls.bind(scheduler),
+    markToolsAsSubmitted,
+  ];
 }
 
 /**


### PR DESCRIPTION
## Summary
- implement `cancelAllToolCalls` in core scheduler
- expose cancel function from `useReactToolScheduler`
- use new cancel method in `useQwenStream` escape handler
- update tests for new behaviour when cancelling tools

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bc77f6b88328b911311981373da6