### PR TITLE
feat(cli): restart chat when switching language

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Switch between English and Chinese with the `/lang` command:
 - Full UI translation (menus, help text, command descriptions)
 - System prompts automatically adapt to selected language
 - Settings are persisted across sessions
+- Changing language restarts the chat session so the new system prompt is used
 
 ### 🤖 Dynamic Model Switching
 Easily switch between Qwen models with the `/model` command:

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -48,6 +48,7 @@ Slash commands provide meta-level control over the CLI itself.
     - System prompts automatically adapt to selected language
     - Settings are persisted across sessions
     - Real-time UI refresh after language change
+    - Changing language restarts the chat session so the new system prompt is used
   - **Supported Languages:**
     - **English** (`en`) - Default interface language
     - **中文简体** (`zh`) - Simplified Chinese interface

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -166,7 +166,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     openLanguageDialog,
     handleLanguageSelect,
     handleLanguageHighlight,
-  } = useLanguageCommand(settings, setLanguageError, addItem, refreshStatic);
+  } = useLanguageCommand(settings, config, setLanguageError, addItem, refreshStatic);
 
   const {
     isModelDialogOpen,

--- a/packages/cli/src/ui/hooks/useLanguageCommand.ts
+++ b/packages/cli/src/ui/hooks/useLanguageCommand.ts
@@ -6,6 +6,7 @@
 
 import { useCallback, useState } from 'react';
 import { LoadedSettings, SettingScope } from '../../config/settings.js';
+import type { Config } from '@qwen/qwen-cli-core';
 import { 
   Language, 
   setLanguage, 
@@ -17,6 +18,7 @@ import { HistoryItem, MessageType } from '../types.js';
 
 export function useLanguageCommand(
   settings: LoadedSettings,
+  config: Config | null,
   setLanguageError: (error: string | null) => void,
   addItem: (item: Omit<HistoryItem, 'id'>, timestamp: number) => void,
   refreshStatic: () => void,
@@ -49,6 +51,8 @@ export function useLanguageCommand(
         
         // Reinitialize translations
         await initializeTranslations();
+        // Restart chat so new system prompt is used
+        await config?.getQwenClient()?.resetChat();
         
         // Add success message
         addItem({
@@ -73,7 +77,7 @@ export function useLanguageCommand(
         }, Date.now());
       }
     },
-    [settings, setLanguageError, addItem, refreshStatic],
+    [settings, config, setLanguageError, addItem, refreshStatic],
   );
 
   const handleLanguageHighlight = useCallback(


### PR DESCRIPTION
## Summary
- restart chat session when changing language
- reinitialize language command with `Config`
- document chat reset when changing language

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6866c13d56b88328a17ad364f5173cd6